### PR TITLE
Enables capitalization for the cleveref package (when writing in English)

### DIFF
--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -67,7 +67,7 @@
 %%%%%%%%%%%%%%%%%%%
 \usepackage{hyperref} % erzeugt aus Referenzen und Web-Adressen Hyperlinks zum Springen im Dokument oder dem Öffnen einer Webseite.
 % https://tex.stackexchange.com/questions/195976/change-the-output-format-of-cref-from-table-to-table-and-from-eq-to-equation
-\usepackage[noabbrev]{cleveref} % automatisches Voranstellen des Referenztyps (z.B. Kapitel)
+\usepackage[noabbrev,capitalise]{cleveref} % automatisches Voranstellen des Referenztyps (z.B. Kapitel)
 %%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
If configured with `english` (instead of `ngerman`), the `cleveref` package does not use capitalization per default. Since this is part of the feedback that some of us repeatedly gave to students, I configured the template to always use capitalization.