### PR TITLE
Adds numbering for sub sub sections + `hyphenat` package for `\texttt` + examples

### DIFF
--- a/aufgabenstellung.tex
+++ b/aufgabenstellung.tex
@@ -60,6 +60,8 @@
 \usepackage{caption}
 \captionsetup{justification=centering}
 
+% Load the hyphenat package to allow auto breaking of \textt(t) strings
+\usepackage[htt]{hyphenat}
 
 
 \begin{document}

--- a/chapters/background.tex
+++ b/chapters/background.tex
@@ -82,3 +82,16 @@ import random
 def get_grade(thesis):
     return random.randrange(1,6)
 \end{lstlisting}
+
+
+\section{Inline Code und/oder Begriffe aus Abbildungen}\label{sect-inline-code}
+
+Um im Fließtext auf Code oder Begriffe (wie z.\,B. Klassennamen) aus Diagrammen zu referenzieren, bietet sich
+\texttt{\textbackslash\-texttt\{inhalt\}}
+an.
+Diese Audrücke werden zu \texttt{inhalt} gerendert.
+
+Eine Schwierigkeit dabei könnte sein, dass die String in diesen Fällen nicht immer automatisch oder korrekt umgebrochen werden.
+Dafür ist wird in diesem Dokument das Paket \texttt{hyphenat} geladen.
+Sollte es einmal Probleme geben, so können LaTeX immer durch \texttt{\textbackslash-} zwischen Silben Hinweise gegeben werden, wie ein Wort zu brechen ist.
+Beispiel: \texttt{\textbackslash\-texttt\{langer\textbackslash-Inhalt\textbackslash-Der\textbackslash-Nicht\textbackslash-Umbricht\}}

--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -50,3 +50,13 @@ Hier ist noch eine Referenz auf ein Buch, die eine Angabe für \textit{Edition} 
 %\lipsum
 
 {\Huge Hier} {\huge steht} {\LARGE ein} {\Large kurzer} {\large Satz} {\normalsize mit} {\small immer} {\footnotesize kleiner} {\scriptsize werdender} {\tiny Schriftgröße}.
+
+\subsection{Überschrift eines Unterabschnittes}\label{subsec:dummy-sub-section}
+
+Ich bin ein Unterabschnitt.
+
+\subsubsection{Überschrift eines weiteren Unter(unter)abschnittes}\label{subsubsec:dummy-sub-sub-section}
+
+Weiter als bis zu dieser Ebene sollte eigentlich nicht verschachtelt werden.
+
+Im Inhaltsverzeichnis tauchen Subsubsections nicht auf.

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -183,6 +183,9 @@
 % Configures the 4th layer (sub sub section) to be also numbered correctly (e.g., 1.2.3.4 instead of 1.2.3)
 \setcounter{secnumdepth}{3}
 
+% Load the hyphenat package to allow auto breaking of \textt(t) strings
+\usepackage[htt]{hyphenat}
+
 \begin{document}
 
 \frontmatter

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -180,6 +180,9 @@
 % Change the font size of URLs globally to a smaller value
 \renewcommand{\UrlFont}{\ttfamily\small}
 
+% Configures the 4th layer (sub sub section) to be also numbered correctly (e.g., 1.2.3.4 instead of 1.2.3)
+\setcounter{secnumdepth}{3}
+
 \begin{document}
 
 \frontmatter


### PR DESCRIPTION
This PR adds:
- numbering for sub sub sections, e.g., *1.2.3.4 Headline*
- explanation/example for sub sub sections
- the `hyphenat` package to break strings in `\texttt{...}`
- explanation/examples for `\texttt{...}` and how to give LaTeX hints on how to break strings by hand