### PR TITLE
Fixes various compiler errors and warnings (esp. on newer Overleaf/ShareLaTeX versions)

### DIFF
--- a/aufgabenstellung.tex
+++ b/aufgabenstellung.tex
@@ -1,4 +1,5 @@
 %!TEX program = lualatex
+% ^use lualatex for best compatibility
 
 % https://github.com/tudace/tuda_latex_templates/issues/472#issuecomment-2203339479
 \DocumentMetadata{
@@ -25,11 +26,11 @@
 % Der folgende Block ist nur bei pdfTeX auf Versionen vor April 2018 notwendig
 \usepackage{iftex}
 \ifPDFTeX
-\usepackage[utf8]{inputenc}%kompatibilität mit TeX Versionen vor April 2018
+\usepackage[utf8]{inputenc}%Kompatibilität mit TeX Versionen vor April 2018
 \fi
 
 %%%%%%%%%%%%%%%%%%%
-%Sprachanpassung und Verbesserte Trennregeln
+%Sprachanpassung und verbesserte Trennregeln
 %%%%%%%%%%%%%%%%%%%
 \usepackage[english, main=ngerman]{babel}
 \usepackage{microtype}
@@ -127,5 +128,5 @@ Dabei kann es helfen, eine Übersichtsgrafik zu verwenden und Forschungsfragen z
 
 \bibliographystyle{plain}
 \bibliography{chapters/references}
-	
+
 \end{document}

--- a/chapters/background.tex
+++ b/chapters/background.tex
@@ -27,6 +27,23 @@ Illustrationen (\cref{fig:some-figure}), andere Elemente wie z.B. Tabellen (\cre
     \caption{Dies ist eine Beispiel-Abbildung, die das Logo des Fachgebiets zeigt.}\label{fig:some-figure}
 \end{figure}
 
+\begin{figure}
+    \centering
+    % Erste Abbildung
+    \begin{subfigure}[b]{0.48\textwidth}
+	\centering
+        \includegraphics[width=.4\linewidth]{figures/es_logo_gross.jpg}
+        \subcaption{Subfigure Bild Nr.\,1}
+    \end{subfigure}
+    % Zweite Abbildung
+    \begin{subfigure}[b]{0.48\textwidth}
+        \centering
+        \includegraphics[width=.4\linewidth]{figures/es_logo_gross.jpg}
+        \subcaption{Subfigure Bild Nr.\,2}
+    \end{subfigure}
+    \caption{Es ist auch möglich Abbildungen mit Unterabbildungen zu erstellen.}\label{fig:some-sub-figure}
+\end{figure}
+
 %\lipsum[4-5]
 
 \begin{definition}[Timed Automaton]\label{def:dummy-def}

--- a/chapters/background.tex
+++ b/chapters/background.tex
@@ -95,3 +95,8 @@ Eine Schwierigkeit dabei könnte sein, dass die String in diesen Fällen nicht i
 Dafür ist wird in diesem Dokument das Paket \texttt{hyphenat} geladen.
 Sollte es einmal Probleme geben, so können LaTeX immer durch \texttt{\textbackslash-} zwischen Silben Hinweise gegeben werden, wie ein Wort zu brechen ist.
 Beispiel: \texttt{\textbackslash\-texttt\{langer\textbackslash-Inhalt\textbackslash-Der\textbackslash-Nicht\textbackslash-Umbricht\}}
+
+\section{Akronyme}\label{acronyms}
+
+% Trigger acronyms
+Dieser Satz steht hier nur drin, um ein Akronym zu triggern: \ac{VM} und nun noch einmal \ac{VM}.

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -62,7 +62,7 @@
 \usepackage{mathtools}  % erweiterte Fassung von amsmath
 \usepackage{amssymb}    % erweiterter Zeichensatz
 % SI Basiseinheiten mit bits und Bytes
-\usepackage[binary-units=true]{siunitx}
+\usepackage{siunitx}
 
 %%%%%%%%%%%%%%%%%%%
 % Code-Listings und Illustrationen

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -192,6 +192,21 @@
 % Load the hyphenat package to allow auto breaking of \textt(t) strings
 \usepackage[htt]{hyphenat}
 
+% Fix acronym/cleveref bug
+% https://tex.stackexchange.com/a/735502
+\makeatletter
+\AtBeginDocument
+ {
+   \def\ltx@label#1{\cref@label{#1}}%add braces
+   \def\label@in@display@noarg#1{\cref@old@label@in@display{#1}}%remove braces
+\def\label@in@mmeasure@noarg#1{%
+    \begingroup%
+      \measuring@false%
+      \cref@old@label@in@display{#1}%remove braces for multline, see https://tex.stackexchange.com/q/737204/2388
+    \endgroup}%  
+ } %
+\makeatother
+
 \begin{document}
 
 \frontmatter
@@ -249,10 +264,10 @@
 \tableofcontents
 \clearpage
 
-% TODO: Das Abkürzungsverzeichnis ist optional! Hier einkommentieren, falls es benutzt werden soll.
+% TODO: Das Abkürzungsverzeichnis ist optional! Hier auskommentieren, falls es nicht benutzt werden soll.
 %% Abkürzungsverzeichnis
-%\input{chapters/abbreviations.tex}
-%\clearpage
+\input{chapters/abbreviations.tex}
+\clearpage
 
 % Auflistung Abbildungen
 % https://tex.stackexchange.com/questions/784/how-to-change-the-line-spacing-in-my-list-of-figures

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -183,14 +183,14 @@
 % Configures the 4th layer (sub sub section) to be also numbered correctly (e.g., 1.2.3.4 instead of 1.2.3)
 \setcounter{secnumdepth}{3}
 
-% Load the hyphenat package to allow auto breaking of \textt(t) strings
-\usepackage[htt]{hyphenat}
-
 % Silence hyphenat-related font warnings
 \usepackage{silence}
 \WarningFilter{latexfont}{Font}
 \WarningFilter{latexfont}{Some}
 \WarningFilter{hyphenat}{***}
+
+% Load the hyphenat package to allow auto breaking of \textt(t) strings
+\usepackage[htt]{hyphenat}
 
 \begin{document}
 

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -33,11 +33,11 @@
 % Der folgende Block ist nur bei pdfTeX auf Versionen vor April 2018 notwendig
 \usepackage{iftex}
 \ifPDFTeX
-\usepackage[utf8]{inputenc}%kompatibilität mit TeX Versionen vor April 2018
+\usepackage[utf8]{inputenc}%Kompatibilität mit TeX Versionen vor April 2018
 \fi
 
 %%%%%%%%%%%%%%%%%%%
-%Sprachanpassung und Verbesserte Trennregeln
+%Sprachanpassung und verbesserte Trennregeln
 %%%%%%%%%%%%%%%%%%%
 \usepackage[english, main=ngerman]{babel} % TODO: Or 'main=english' if you write in English
 \usepackage{microtype}
@@ -51,7 +51,7 @@
 %Tabellen
 %%%%%%%%%%%%%%%%%%%
 %\usepackage{array}     % Basispaket für Tabellenkonfiguration, wird von den folgenden automatisch geladen
-\usepackage{tabularx}  % Tabellen, die sich automatisch der Breite anpassen
+\usepackage{tabularx}   % Tabellen, die sich automatisch der Breite anpassen
 %\usepackage{longtable} % Mehrseitige Tabellen
 %\usepackage{xltabular} % Mehrseitige Tabellen mit anpassarer Breite
 \usepackage{booktabs}   % Verbesserte Möglichkeiten für Tabellenlayout über horizontale Linien
@@ -67,7 +67,7 @@
 %%%%%%%%%%%%%%%%%%%
 % Code-Listings und Illustrationen
 %%%%%%%%%%%%%%%%%%%
-\usepackage{listings}   % ermöglicht es Quell-code schön darzustellen
+\usepackage{listings}   % ermöglicht es Quellcode schön darzustellen
 \usepackage{graphicx}
 %%%%%%%%%%%%%%%%%%%
 
@@ -203,7 +203,7 @@
 % TODO: Nach Anmeldegespräch Nummer bei Betreuer erfragen und hier anpassen!
 \titleaddendum{ES-M-123}
 
-%Diese Felder werden untereinander auf der Titelseite platziert. 
+%Diese Felder werden untereinander auf der Titelseite platziert.
 \department{etit} % Das Kürzel wird automatisch ersetzt und als Studienfach gewählt, siehe Liste der Kürzel im Dokument.
 \group{Fachgebiet Echtzeitsysteme}
 % TODO: Or 'Real-Time Systems Lab' if you write in English
@@ -221,8 +221,8 @@
 \maketitle
 
 % TODO
-\affidavit % benutzen, wenn die Thesis gedruckt und digital eingereicht wird
-% \affidavit[digital] % benutzen, wenn die Thesis ausschließlich digital eingereicht wird
+%\affidavit % benutzen, wenn die Thesis gedruckt und digital eingereicht wird
+\affidavit[digital] % benutzen, wenn die Thesis ausschließlich digital eingereicht wird
 
 \input{chapters/guidelines}
 
@@ -275,5 +275,5 @@
 
 % TODO: Der Anhang ist optional, falls gewünscht bitte einkommentieren!
 %\input{chapters/appendix.tex}
-	
+
 \end{document}

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -186,6 +186,12 @@
 % Load the hyphenat package to allow auto breaking of \textt(t) strings
 \usepackage[htt]{hyphenat}
 
+% Silence hyphenat-related font warnings
+\usepackage{silence}
+\WarningFilter{latexfont}{Font}
+\WarningFilter{latexfont}{Some}
+\WarningFilter{hyphenat}{***}
+
 \begin{document}
 
 \frontmatter

--- a/thesis-main.tex
+++ b/thesis-main.tex
@@ -196,9 +196,16 @@
 
 \frontmatter
 
-\Metadata{
-	title=Hier steht der mehrzeilige Titel der Thesis,
-	author=Jane Doe
+% Old way of passing metadata
+% \Metadata{
+% 	title=Hier steht der mehrzeilige Titel der Thesis,
+% 	author=Jane Doe
+% }
+% New way of (explicitely) passing metadata
+\hypersetup{% Metadata adjustments, in case these are not set, the data provided for \maketitle will be used
+	pdfauthor=Jane Doe,
+	pdfcreationdate=\today,
+	pdfkeywords={TU Darmstadt; FB18; ES}
 }
 
 \title{Hier steht der mehrzeilige Titel der Thesis}


### PR DESCRIPTION
This PR addresses various compiler errors and warnings (especially on newer versions of Overleaf/ShareLaTeX), corrects some comments, and expands the figure example for subfigures.

Details:
- Typo fixes in comments.
- Changes the default behavior of the `thesis-main.tex` to "digital submission only", as this is the standard for a few years.
- Fixes a warning of the package `siunitx`. (Our template did use a deprecated option that is not necessary anymore.)
- Silences font warnings concerning the package `hyphenat`, which we use to allow the automatic line breaking of `\textt` and `\texttt`.
- The `tuda-ci` package/template did change the way an author should pass metadata to the compiler. The old variant in our template generated a warning, which was fixed.
- In newer versions of the package `acronym`, a warning was generated because of an old bug fix in the package `cleveref` (don't ask me ...). This was also fixed.
- I added an example on how to use subfigures in the document, which also removes a compiler warning that no subfigure environment was used.